### PR TITLE
mergify: configure to wait longer for renovate and sync PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,7 +6,7 @@ queue_rules:
     conditions:
       - check-success=Good to merge
     batch_size: 10
-    batch_max_wait_time: 15min
+    batch_max_wait_time: 90min
     merge_method: rebase
 
 pull_request_rules:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,7 +13,9 @@ pull_request_rules:
   - name: Automatic merge from renovate
     conditions:
       - check-success=Good to merge
-      - author=renovate[bot]
+      - or:
+          - author=renovate[bot]
+          - label=file-sync
     actions:
       queue:
         name: deps-update

--- a/.github/workflows/repo-files-sync.yml
+++ b/.github/workflows/repo-files-sync.yml
@@ -46,3 +46,5 @@ jobs:
         with:
           GH_PAT: ${{ secrets.REPO_SYNC_PAT }}
           COMMIT_EACH_FILE: false  # Commit all files at once
+          PR_LABELS: |
+            file-sync


### PR DESCRIPTION
- ci(sync): add labels for synching pull requests
- ci(mergify): also enqueue file sync pull requests
- ci(mergify): wait longer to merge enqueued pull requests
